### PR TITLE
Add flag "--force" to Line 73

### DIFF
--- a/zh_CN/advanced/tls.md
+++ b/zh_CN/advanced/tls.md
@@ -70,7 +70,7 @@ $ sudo apt-get install openssl cron socat curl
 
 以下的命令会临时监听 80 端口，请确保执行该命令前 80 端口没有使用
 ```plain
-$ sudo ~/.acme.sh/acme.sh --issue -d mydomain.me --standalone --keylength ec-256
+$ sudo ~/.acme.sh/acme.sh --issue -d mydomain.me --standalone --keylength ec-256 --force
 [Fri Dec 30 08:59:12 HKT 2016] Standalone mode.
 [Fri Dec 30 08:59:12 HKT 2016] Single domain='mydomain.me'
 [Fri Dec 30 08:59:12 HKT 2016] Getting domain auth token for each domain


### PR DESCRIPTION
Under Ubuntu 18.04, if use this command directly:
```plain
sudo ~/.acme.sh/acme.sh --issue -d mydomain.me --standalone --keylength ec-256
```
CLI shows:
```plain
It seems that you are using sudo, please read this link first:
https://github.com/acmesh-official/acme.sh/wiki/sudo
```
If remove the "sudo", CLI shows error:
```plain
...
2020/05/09 21:03:28 socat[2038] E bind(5, {AF=2 0.0.0.0:80}, 16): Permission denied
[Sat May  9 21:03:33 HKT 2020] mydomain.me:Verify error:Invalid response from http://mydomain.me/.well-known/acme-challenge/seMUrEsUr47-Lc9Nc7cS3xQO8VmhVMjfXhw0wcGEmIc [64.32.28.244]: 
/home/naidaomeihui/.acme.sh/acme.sh: line 2271: kill: (2038) - No such process
[Sat May  9 21:03:33 HKT 2020] Please add '--debug' or '--log' to check more details.
[Sat May  9 21:03:33 HKT 2020] See: https://github.com/acmesh-official/acme.sh/wiki/How-to-debug-acme.sh
...
```
Finally, according to [https://github.com/acmesh-official/acme.sh/wiki/sudo], add --force at the end:
```plain
sudo ~/.acme.sh/acme.sh --issue -d mydomain.me --standalone --keylength ec-256 --force
```
Succeed.