### PR TITLE
:pencil:更新tls.md和wss_and_web.md

### DIFF
--- a/zh_CN/advanced/tls.md
+++ b/zh_CN/advanced/tls.md
@@ -70,7 +70,7 @@ $ sudo apt-get install openssl cron socat curl
 
 以下的命令会临时监听 80 端口，请确保执行该命令前 80 端口没有使用
 ```plain
-$ sudo ~/.acme.sh/acme.sh --issue -d mydomain.me --standalone --keylength ec-256 --force
+$ ~/.acme.sh/acme.sh --issue -d mydomain.me --standalone --keylength ec-256 --force
 [Fri Dec 30 08:59:12 HKT 2016] Standalone mode.
 [Fri Dec 30 08:59:12 HKT 2016] Single domain='mydomain.me'
 [Fri Dec 30 08:59:12 HKT 2016] Getting domain auth token for each domain
@@ -109,7 +109,7 @@ gPUI45eltrjcv8FCSTOUcT7PWCa3
 手动更新证书，执行：
 
 ```plain
-$ sudo ~/.acme.sh/acme.sh --renew -d mydomain.com --force --ecc
+$ ~/.acme.sh/acme.sh --renew -d mydomain.com --force --ecc
 ```
 
 **由于本例中将证书生成到 `/etc/v2ray/` 文件夹，更新证书之后还得把新证书生成到 /etc/v2ray。**

--- a/zh_CN/advanced/wss_and_web.md
+++ b/zh_CN/advanced/wss_and_web.md
@@ -55,7 +55,7 @@ Nginx 配置和 Apache 配置中使用的是域名和证书使用 TLS 小节的�
 证书生成
 
 ```plain
-$ sudo ~/.acme.sh/acme.sh --issue -d mydomain.me --webroot --keylength ec-256
+$ ~/.acme.sh/acme.sh --issue -d mydomain.me --webroot --keylength ec-256
 ```
 
 安装证书和密钥
@@ -104,7 +104,30 @@ server {
 
 #### Caddy 配置 
 
+在配置之前请先检查当前安装的Caddy的版本，两者的配置格式并不完全兼容。推荐安装Caddy v2。
+
 ```plain
+# Caddy v2 (recommand)
+mydomain.me {
+    log {
+        output file /etc/caddy/caddy.log
+    }
+    tls {
+        protocols tls1.2 tls1.3
+        ciphers TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+        curves x25519
+    }
+    @v2ray_websocket {
+        path /ray
+        header Connection Upgrade
+        header Upgrade websocket
+    }
+    reverse_proxy @v2ray_websocket localhost:10000
+}
+```
+
+```plain
+# Caddy v1 (deprecate)
 mydomain.me
 {
   log ./caddy.log

--- a/zh_CN/advanced/wss_and_web.md
+++ b/zh_CN/advanced/wss_and_web.md
@@ -104,10 +104,12 @@ server {
 
 #### Caddy 配置 
 
-在配置之前请先检查当前安装的Caddy的版本，两者的配置格式并不完全兼容。推荐安装Caddy v2。
+::: tip
+  在配置之前请先检查当前安装的 Caddy 的版本，两者的配置格式并不完全兼容。推荐使用 Caddy v2。
+:::
 
 ```plain
-# Caddy v2 (recommand)
+# Caddy v2 (recommended)
 mydomain.me {
     log {
         output file /etc/caddy/caddy.log
@@ -127,7 +129,7 @@ mydomain.me {
 ```
 
 ```plain
-# Caddy v1 (deprecate)
+# Caddy v1 (deprecated)
 mydomain.me
 {
   log ./caddy.log


### PR DESCRIPTION
1. 通过acme.sh申请证书时，除安装证书可能需要sudo外，删去所有证书申请命令中的sudo。
参考：https://github.com/acmesh-official/acme.sh/wiki/sudo

2. 更新Caddy v2的配置方法
log部分参考：https://caddyserver.com/docs/caddyfile/directives/log
tls部分参考：https://caddyserver.com/docs/caddyfile/directives/tls
path部分参考：https://caddyserver.com/docs/caddyfile/matchers#named-matchers
除自动申请证书外，该Caddy配置经测试可用。