### PR TITLE
simple tls-based router by nginx/openresty

### DIFF
--- a/zh_CN/advanced/simple_tls_route_by_nginx.md
+++ b/zh_CN/advanced/simple_tls_route_by_nginx.md
@@ -1,0 +1,203 @@
+# 一、摘要
+基于协议数据的统一的代理分流工具。nignx 作为前端，tls 终止并基于 tls 承载的数据进行分流。简单易安装，仅仅添加 21 行代码。简化官方 TCP + TLS + Web 方案；去掉了 / 替换 tls 分流器；也可以分流到 trojan；让 nginx 可以路由到 v2 的 http2 方案。
+# 二、目的
+看到有人根据 trojan 原理基于 v2ray 做了个类似功能的定制即 TCP + TLS + Web，就是在 TLS 层上传输 vmess 或者其他比如 http web 流量。
+本人好奇，遂群里有如下互动：
+
+Q:TCP + TLS + Web 为啥需要 web 前需要 hproxy 啊，nginx 也有这种功能啊 非要前面 hproxy，后面再弄个 nginx/httpd。 对于个人使用没必要吧。 当然你搭建商业的除外
+A: 不要再问这种问题了，你觉得可以就自己搭，搭成了可以写给教程 pr
+Q:nginx 的 stream 块不行吗
+A: 不要再问这种问题了，你觉得可以就自己搭，搭成了可以写给教程 pr
+
+所以目的很简单，就是去掉那个 haproxy, 只用 nginx 来分流，这样更适用于个人 vps 的搭建。
+另外的一个目的，也作为 trojan 的前端，即 nginx 也可以分流到 trojan 后端。
+
+
+
+
+# 三、方案的可行性分析
+所有的 tls 在 nginx 终止，后端代理只进行明文协议的解析和处理，不做 tls 处理。
+## 基于 SNI
+有些域名既可以放我们的博客或网站，也可以放到我们的代理客户端的 SNI 里，所以不考虑 SNI 的分流。
+## 基于 SSL 握手后的 app 数据分流
+根据 TSL 握手后的数据进行分流，这里从 tcp/udp 层面考虑，tls 之上的数据都是需要我们分流的。所以对于 nginx，我们采用 stream 的配置方式。
+如果是 HTTP1.1，就让直接到某个正常的网站，这里要求我们没有把代理协议承载在 https 上。
+如果是 HTTP2， 就让路由到 h2 代理后端比如 v2ray 或者 trojan. 虽然 trojan-go 支持 http2，但考虑到 trojangfw 反对 http2 的引入，所以我们的实现也不考虑 trojan-go 的 http2. 这里要求 v 端的实现可以考虑到正常 http2 req 的网站的返回即 failback（目前没有实现）。
+如果是裸的 vmess 协议数据即常说的 TCP+TLS+VMESS+WEB，直接转发到 v 后端，这里要求 v 后端在解析失败的情况下可以返回错误页面以便伪装，也是另一种 failback（目前 v 官方没有实现，倒是有个[开源实现](https://gist.github.com/liberal-boy/04f875b86a5e54cb4e1752d24077f2be)).
+如果是裸的 trojan 协议数据，直接转发到 tj 后端。 这里 trojan 实现了 failback。
+
+# 四、此方案与 trojan 的区别
+* Active Detection
+对于 tj，All connection without correct structure and password will be redirected to a preset endpoint,including normal https traffic and  faked traffic。 但是对于 v2ray 却没有这样的功能，即上面所提的 failback 功能。当然社区有人在做了。
+* Passive Detection
+Tj 的被动检测方法是 if you are not visiting an HTTP site, then the traffic looks the same as HTTPS kept alive or WebSocket. Because of this, trojan can also bypass ISP QoS limitations. 对于我们这么部署 v2ray 的方式，也是具有这样的功能的。
+这样部署的 trojgan-go 只不过把所有 tls 的功能放到 nginx 上，其他功能还在后端 tj 上。
+
+# 五、实现
+## install nginx distribution Openresty
+我们采用 luajit 来实现。Openresty 安装参考[官方指导](https://openresty.org/en/installation.html).
+Debian 上的安装方法：
+```
+sudo systemctl disable nginx
+sudo systemctl stop nginx
+sudo apt-get -y install --no-install-recommends wget gnupg ca-certificates
+wget -O - https://openresty.org/package/pubkey.gpg | sudo apt-key add -
+
+# add this to /etc/apt/sources.list
+codename=`grep -Po 'VERSION="[0-9]+ \(\K[^)]+' /etc/os-release`
+
+echo "deb http://openresty.org/package/debian $codename openresty" \
+    | sudo tee /etc/apt/sources.list.d/openresty.list
+
+# end
+sudo apt-get update
+sudo apt-get -y install openresty
+```
+## nginx config file
+```
+{
+worker_processes  auto;
+error_log  logs/error.log  info;
+events {
+    worker_connections  1024;
+    use epoll;
+    multi_accept on;
+}
+stream {
+    resolver 127.0.0.1;
+    lua_add_variable $vmess;
+
+    server {
+        listen  443 ssl reuseport backlog=4096;
+        listen [::]:443 ssl reuseport;
+
+        ssl_certificate_key   /privatekey.pem;
+        ssl_certificate       /fullchain.pem;
+
+
+        ssl_session_timeout 1d;
+        ssl_session_cache shared:SSL:20m;
+        ssl_protocols TLSv1.1 TLSv1 TLSv1.2;
+        ssl_ciphers ALL:!ADH:!EXPORT56:RC4+RSA:+HIGH:+MEDIUM:+LOW:+SSLv3:+EXP;
+        ssl_prefer_server_ciphers on;
+
+        # 16k
+        proxy_buffer_size          256k;
+        # 16k
+       # preread_buffer_size 4k;
+        preread_buffer_size 58;
+
+        preread_by_lua_block {
+            local sock, err = ngx.req.socket()
+            if sock then
+               -- ngx.say("got the request socket")
+            else
+                ngx.say("failed to get the request socket: ", err)
+            end
+
+            local data, err = sock:peek(16)
+            local datal, err = sock:peek(58)
+            if string.match(data, "HTTP/2.0") then
+                -- maybe faked http2 to detect us ,so need parse the body to failback to normal url
+                -- or by vmess
+                -- maybe we use trojan-go http2,but now giveup
+
+		-- for v2ray's tcp +tls +h2c
+                ngx.var.vmess = "10008"
+            elseif string.match(data, "HTTP") then
+	        -- for normal http req
+                ngx.var.vmess = "8080"
+            elseif string.byte(datal:sub(57), 1, 2) == 13 then
+	        -- for trojan
+                ngx.var.vmess = "453"
+            else
+	        -- for v2ray's tcp+tls +web
+                ngx.var.vmess = "10007"
+            end
+        }
+         proxy_pass 127.0.0.1:$vmess;
+  }# server block
+}
+
+```
+## 创建 nginx 目录 a
+rsync -av /usr/local/openresty/nginx/[conf,html,logs] a
+cd a
+修改 a 下 conf/nginx.conf 为如上配置。
+sudo openresty -p .
+sudo openresty -p . -s reload
+这样可以不污染 /usr/local/openresty/nginx 下的配置。
+
+## v's tcp +tls +h2c  config
+见 [HTTP/2+TLS+WEB](https://guide.v2fly.org/advanced/h2_tls_web.html#%E7%BC%BA%E9%99%B7)
+注意这里 h2 的 tls 在 nginx 实现，即 h2c 配置。
+对此参考的改进是采用了 nginx 作为前端。
+android v2rayng version 1.2.6 有个 bug： 设置 allowsecure=true 不起作用，当然如果你的服务器 cert 正常，一般就设置为 false 就好。
+
+
+## v's tcp+tls +web  config
+可以参考 [TCP + TLS + Web](https://guide.v2fly.org/advanced/tcp_tls_web.html#%E8%83%8C%E6%99%AF) 的服务器配置。
+与此参考不同的是去掉 haproxy。并且基于协议内容分流而不是 SNI。相对 [TCP+TLS 分流器](https://guide.v2fly.org/advanced/tcp_tls_shunt_proxy.html), 这个方案更简单了。
+
+## trojan-go
+禁止 tls 的处理的 trojan-go 版本目前处于 github 的 [dev 分支](https://github.com/p4gefau1t/trojan-go/commits/dev). 需要自行编译相应架构的客户端或者服务器端。
+server config
+```
+{
+    "run_type": "server",
+    "local_addr": "127.0.0.1",
+    "local_port": 453,
+    "remote_addr": "127.0.0.1",
+    "remote_port": 80,
+    "password": [
+        "xxxx"
+    ],
+    "ssl": {
+        "serve_plain_text": true
+    }
+}
+```
+client config 如正常的 tj 配置。
+
+# 六、性能
+* vmessping 延迟 benchmark
+```
+tcp+tls+web
+--- vmess ping statistics ---
+10 requests made, 10 success, total time 26.515340739s
+rtt min/avg/max = 993/1748/2544 ms
+
+tls+ws+cdn
+--- vmess ping statistics ---
+10 requests made, 10 success, total time 30.647379082s
+rtt min/avg/max = 1215/2161/7160 ms
+
+tls+h2c
+--- vmess ping statistics ---
+10 requests made, 10 success, total time 20.977310488s
+rtt min/avg/max = 616/1194/3263 ms
+```
+最好的延迟是 tls+ h2c .
+按理说 tcp+tls （即 tcp+tls+web，没有 http 开销） 应该比 tls+h2c 好点吧，这里为什么性能还弱呢？
+* 浏览器 client 性能 benchmark
+todo
+
+
+# 七、todo 和讨论
+## ssl 的 nginx 配置
+不要用提供的，请尽量使用推荐的配置
+## 可否做不同后端的负载均衡
+## v2ray 的 failback 实现
+不合适在 nginx 上实现，因为需要解析对应的协议。
+只能在 v2ray 上实现。
+
+
+
+
+# 八、参考
+
+https://github.com/trojan-gfw/trojan/issues/14
+https://trojan-gfw.github.io/trojan/protocol
+[Vmess + TCP + TLS 方式的 HTTP 分流和网站伪装](https://gist.github.com/liberal-boy/f3db4e413a96fa80719db1414f011325)
+[Vmess Fail Redirect 简单实现](https://gist.github.com/liberal-boy/04f875b86a5e54cb4e1752d24077f2be)
+

--- a/zh_CN/advanced/simple_tls_route_by_nginx.md
+++ b/zh_CN/advanced/simple_tls_route_by_nginx.md
@@ -1,43 +1,42 @@
-# 一、摘要
-基于协议数据的统一的代理分流工具。nignx 作为前端，tls 终止并基于 tls 承载的数据进行分流。简单易安装，仅仅添加 21 行代码。简化官方 TCP + TLS + Web 方案；去掉了 / 替换 tls 分流器；也可以分流到 trojan；让 nginx 可以路由到 v2 的 http2 方案。
-# 二、目的
-看到有人根据 trojan 原理基于 v2ray 做了个类似功能的定制即 TCP + TLS + Web，就是在 TLS 层上传输 vmess 或者其他比如 http web 流量。
+# 基于 Nginx 的简单 TLS 分流方案
+本节提供了基于协议数据的统一的代理分流方案，其使用 Nginx 作为前端对基于 TLS 承载的数据进行分流，简化了现有的 TCP+TLS+Web 方案并同时支持分流到 Trojan或 V2Ray 的 HTTP2。
+## 目的
+看到有人根据 Trojan 原理基于 V2Ray 做了个类似功能的定制即 TCP + TLS + Web，就是在 TLS 层上传输 VMess 或者其他比如 http web 流量。
 本人好奇，遂群里有如下互动：
 
-Q:TCP + TLS + Web 为啥需要 web 前需要 hproxy 啊，nginx 也有这种功能啊 非要前面 hproxy，后面再弄个 nginx/httpd。 对于个人使用没必要吧。 当然你搭建商业的除外
-A: 不要再问这种问题了，你觉得可以就自己搭，搭成了可以写给教程 pr
-Q:nginx 的 stream 块不行吗
-A: 不要再问这种问题了，你觉得可以就自己搭，搭成了可以写给教程 pr
+> Q: TCP + TLS + Web 为啥需要 web 前需要 HAProxy 啊，nginx 也有这种功能啊 非要前面 HAProxy，后面再弄个 nginx/httpd。 对于个人使用没必要吧。 当然你搭建商业的除外
+> A: 不要再问这种问题了，你觉得可以就自己搭，搭成了可以写给教程 pr
+> Q: nginx 的 stream 块不行吗
+> A: 不要再问这种问题了，你觉得可以就自己搭，搭成了可以写给教程 pr
 
-所以目的很简单，就是去掉那个 haproxy, 只用 nginx 来分流，这样更适用于个人 vps 的搭建。
-另外的一个目的，也作为 trojan 的前端，即 nginx 也可以分流到 trojan 后端。
+所以目的很简单，就是去掉那个 HAProxy，只用 Nginx 来分流，这样更适用于个人 vps 的搭建。
+另外的一个目的，也作为 Trojan 的前端，即 Nginx 也可以分流到 Trojan 后端。
 
+## 可行性分析
+所有的 TLS 处理在 Nginx 截止，后端代理只进行明文协议的解析。有些域名既可以指向网站，也可以放到我们的代理客户端的 SNI 中处理，故本篇不考虑 SNI 的分流。
 
+## 基于 TLS 握手后的数据包分流
+由于原理是根据 TLS 握手后的数据进行分流，对 Nginx 采用 stream 的配置方式，具体如下：
+ - 如果是 HTTP/1.1，直接路由到某个正常的网站，这要求我们没有把代理协议承载在 HTTPS/1.1 上；
+ - 如果是 HTTP/2，就路由到 HTTP/2 代理后端比如 V2Ray 或 Trojan。尽管 Trojan-Go 支持 HTTP2，但鉴于 Trojan-GFW 项目组对引入 HTTP/2 的反对，所以我们的实现也不考虑 Trojan-Go 的 HTTP/2 实现。这就要求 V2Ray 支持对其他来源的 HTTP/2 网站请求的返回即自动回落，但目前尚没有支持。
+ - 如果是纯 VMess 协议数据即常说的 TCP+TLS+VMess+Web，直接转发到 V2Ray，这同样需要 V2Ray 在解析失败的情况下返回一个普通网页以实现伪装，算是另一种自动回落机制。目前 V2Ray 没有相关实现，但有个[开源实现](https://gist.github.com/liberal-boy/04f875b86a5e54cb4e1752d24077f2be) 可供参考或使用。
+ - 如果是纯 Trojan 协议数据，直接转发到 Trojan 后端，这里 Trojan 实现了协议自动回落。
 
+## 与 Trojan 的比较
+### 主动探测
+对于 Trojan，所有没有提供正确数据结果或密码的请求都会被转至一个预设的出口，包括普通HTTPS流量或重放、伪造的流量；但是目前 V2Ray 没有这样的功能，即上面所提的 *协议自动回落* 功能，不过社区在做了。
+### 被动探测
+Trojan 对抗被动探测方法和本篇所描述的方案基本一致，即所有代理流量表现形如 HTTPS 或 WebSocket。本方案中所有 TLS 的功能都被放到了 Nginx 上，其他功能还在后端 Trojan 或 V2Ray 上。
 
-# 三、方案的可行性分析
-所有的 tls 在 nginx 终止，后端代理只进行明文协议的解析和处理，不做 tls 处理。
-## 基于 SNI
-有些域名既可以放我们的博客或网站，也可以放到我们的代理客户端的 SNI 里，所以不考虑 SNI 的分流。
-## 基于 SSL 握手后的 app 数据分流
-根据 TSL 握手后的数据进行分流，这里从 tcp/udp 层面考虑，tls 之上的数据都是需要我们分流的。所以对于 nginx，我们采用 stream 的配置方式。
-如果是 HTTP1.1，就让直接到某个正常的网站，这里要求我们没有把代理协议承载在 https 上。
-如果是 HTTP2， 就让路由到 h2 代理后端比如 v2ray 或者 trojan. 虽然 trojan-go 支持 http2，但考虑到 trojangfw 反对 http2 的引入，所以我们的实现也不考虑 trojan-go 的 http2. 这里要求 v 端的实现可以考虑到正常 http2 req 的网站的返回即 failback（目前没有实现）。
-如果是裸的 vmess 协议数据即常说的 TCP+TLS+VMESS+WEB，直接转发到 v 后端，这里要求 v 后端在解析失败的情况下可以返回错误页面以便伪装，也是另一种 failback（目前 v 官方没有实现，倒是有个[开源实现](https://gist.github.com/liberal-boy/04f875b86a5e54cb4e1752d24077f2be)).
-如果是裸的 trojan 协议数据，直接转发到 tj 后端。 这里 trojan 实现了 failback。
+## 具体实现
+::: warning
+本节提供的安装示例基于 Debian，请酌情做必要的修改。
+:::
 
-# 四、此方案与 trojan 的区别
-* Active Detection
-对于 tj，All connection without correct structure and password will be redirected to a preset endpoint,including normal https traffic and  faked traffic。 但是对于 v2ray 却没有这样的功能，即上面所提的 failback 功能。当然社区有人在做了。
-* Passive Detection
-Tj 的被动检测方法是 if you are not visiting an HTTP site, then the traffic looks the same as HTTPS kept alive or WebSocket. Because of this, trojan can also bypass ISP QoS limitations. 对于我们这么部署 v2ray 的方式，也是具有这样的功能的。
-这样部署的 trojgan-go 只不过把所有 tls 的功能放到 nginx 上，其他功能还在后端 tj 上。
+### 安装 OpenResty （Nginx 分支）
+我们采用 luajit 来实现，OpenResty 安装参考详见[官方指导](https://openresty.org/en/installation.html)。
 
-# 五、实现
-## install nginx distribution Openresty
-我们采用 luajit 来实现。Openresty 安装参考[官方指导](https://openresty.org/en/installation.html).
-Debian 上的安装方法：
-```
+```bash
 sudo systemctl disable nginx
 sudo systemctl stop nginx
 sudo apt-get -y install --no-install-recommends wget gnupg ca-certificates
@@ -53,8 +52,9 @@ echo "deb http://openresty.org/package/debian $codename openresty" \
 sudo apt-get update
 sudo apt-get -y install openresty
 ```
-## nginx config file
-```
+
+### Nginx 配置
+```plain
 {
 worker_processes  auto;
 error_log  logs/error.log  info;
@@ -65,7 +65,7 @@ events {
 }
 stream {
     resolver 127.0.0.1;
-    lua_add_variable $vmess;
+    lua_add_variable $VMess;
 
     server {
         listen  443 ssl reuseport backlog=4096;
@@ -82,9 +82,9 @@ stream {
         ssl_prefer_server_ciphers on;
 
         # 16k
-        proxy_buffer_size          256k;
+        proxy_buffer_size 256k;
         # 16k
-       # preread_buffer_size 4k;
+        # preread_buffer_size 4k;
         preread_buffer_size 58;
 
         preread_by_lua_block {
@@ -98,51 +98,49 @@ stream {
             local data, err = sock:peek(16)
             local datal, err = sock:peek(58)
             if string.match(data, "HTTP/2.0") then
-                -- maybe faked http2 to detect us ,so need parse the body to failback to normal url
-                -- or by vmess
-                -- maybe we use trojan-go http2,but now giveup
+                -- maybe faked http2 to detect us ,so need parse the body to 协议自动回落 to normal url
+                -- or by VMess
+                -- maybe we use Trojan-go http2,but now giveup
 
-		-- for v2ray's tcp +tls +h2c
-                ngx.var.vmess = "10008"
+        -- for V2Ray's tcp +TLS +h2c
+                ngx.var.VMess = "10008"
             elseif string.match(data, "HTTP") then
-	        -- for normal http req
-                ngx.var.vmess = "8080"
+            -- for normal http req
+                ngx.var.VMess = "8080"
             elseif string.byte(datal:sub(57), 1, 2) == 13 then
-	        -- for trojan
-                ngx.var.vmess = "453"
+            -- for Trojan
+                ngx.var.VMess = "453"
             else
-	        -- for v2ray's tcp+tls +web
-                ngx.var.vmess = "10007"
+            -- for V2Ray's tcp+TLS +web
+                ngx.var.VMess = "10007"
             end
         }
-         proxy_pass 127.0.0.1:$vmess;
+         proxy_pass 127.0.0.1:$VMess;
   }# server block
 }
 
 ```
-## 创建 nginx 目录 a
+
+### 创建 Nginx 目录 'a'
+修改 a 中 `conf/nginx.conf` 为如上配置，这样可以不污染 `/usr/local/openresty/nginx` 下的内容。
+```bash
 rsync -av /usr/local/openresty/nginx/[conf,html,logs] a
 cd a
-修改 a 下 conf/nginx.conf 为如上配置。
 sudo openresty -p .
 sudo openresty -p . -s reload
-这样可以不污染 /usr/local/openresty/nginx 下的配置。
-
-## v's tcp +tls +h2c  config
-见 [HTTP/2+TLS+WEB](https://guide.v2fly.org/advanced/h2_tls_web.html#%E7%BC%BA%E9%99%B7)
-注意这里 h2 的 tls 在 nginx 实现，即 h2c 配置。
-对此参考的改进是采用了 nginx 作为前端。
-android v2rayng version 1.2.6 有个 bug： 设置 allowsecure=true 不起作用，当然如果你的服务器 cert 正常，一般就设置为 false 就好。
-
-
-## v's tcp+tls +web  config
-可以参考 [TCP + TLS + Web](https://guide.v2fly.org/advanced/tcp_tls_web.html#%E8%83%8C%E6%99%AF) 的服务器配置。
-与此参考不同的是去掉 haproxy。并且基于协议内容分流而不是 SNI。相对 [TCP+TLS 分流器](https://guide.v2fly.org/advanced/tcp_tls_shunt_proxy.html), 这个方案更简单了。
-
-## trojan-go
-禁止 tls 的处理的 trojan-go 版本目前处于 github 的 [dev 分支](https://github.com/p4gefau1t/trojan-go/commits/dev). 需要自行编译相应架构的客户端或者服务器端。
-server config
 ```
+
+### V2Ray 配置
+可以参考 [HTTP2+TLS+Web](https://guide.v2fly.org/advanced/h2_tls_web.html#%E7%BC%BA%E9%99%B7) 和 [TCP+TLS+Web](https://guide.v2fly.org/advanced/tcp_tls_web.html#%E8%83%8C%E6%99%AF) 的服务器配置。
+对于 HTTP2+TLS+Web，注意这里 HTTP2 的 TLS 在 Nginx 实现，即 h2c 配置。本篇的改动是采用了 Nginx 作为前端。
+
+对于 TCP+TLS+Web，不同的是去掉 HAProxy，并且基于协议内容分流而不是 SNI。相对 [TCP+TLS 分流器](https://guide.v2fly.org/advanced/tcp_tls_shunt_proxy.html)，本方案更简洁。
+
+### Trojan-Go
+关闭了 TLS 处理的 Trojan-Go 版本目前位于 [dev 分支](https://github.com/p4gefau1t/Trojan-go/commits/dev)，需要自行编译相应架构的客户端或者服务器端。
+
+Trojan-Go 服务端配置如下：
+```json
 {
     "run_type": "server",
     "local_addr": "127.0.0.1",
@@ -157,47 +155,32 @@ server config
     }
 }
 ```
-client config 如正常的 tj 配置。
 
-# 六、性能
-* vmessping 延迟 benchmark
+客户端使用正常的 Trojan 配置即可。
+
+## 性能测试
+### vmessping 延迟测试
 ```
-tcp+tls+web
---- vmess ping statistics ---
+TCP+TLS+Web
+--- VMess ping statistics ---
 10 requests made, 10 success, total time 26.515340739s
 rtt min/avg/max = 993/1748/2544 ms
 
-tls+ws+cdn
---- vmess ping statistics ---
+TLS+WebSocket+CDN
+--- VMess ping statistics ---
 10 requests made, 10 success, total time 30.647379082s
 rtt min/avg/max = 1215/2161/7160 ms
 
-tls+h2c
---- vmess ping statistics ---
+TLS+h2c
+--- VMess ping statistics ---
 10 requests made, 10 success, total time 20.977310488s
 rtt min/avg/max = 616/1194/3263 ms
 ```
-最好的延迟是 tls+ h2c .
-按理说 tcp+tls （即 tcp+tls+web，没有 http 开销） 应该比 tls+h2c 好点吧，这里为什么性能还弱呢？
-* 浏览器 client 性能 benchmark
-todo
+可见延迟表现最佳的是 TLS + h2c。
+按理说 TCP+TLS （即 TCP+TLS+Web，没有 HTTP 开销） 应该比 TLS+h2c 更好，这里为什么性能还弱呢？
 
-
-# 七、todo 和讨论
-## ssl 的 nginx 配置
-不要用提供的，请尽量使用推荐的配置
-## 可否做不同后端的负载均衡
-## v2ray 的 failback 实现
-不合适在 nginx 上实现，因为需要解析对应的协议。
-只能在 v2ray 上实现。
-
-
-
-
-# 八、参考
-
-https://github.com/trojan-gfw/trojan/issues/14
-https://trojan-gfw.github.io/trojan/protocol
-[Vmess + TCP + TLS 方式的 HTTP 分流和网站伪装](https://gist.github.com/liberal-boy/f3db4e413a96fa80719db1414f011325)
-[Vmess Fail Redirect 简单实现](https://gist.github.com/liberal-boy/04f875b86a5e54cb4e1752d24077f2be)
-
+## 参考
+[Trojan Design discussion #14](https://github.com/Trojan-gfw/Trojan/issues/14)
+[The Trojan Protocol](https://Trojan-gfw.github.io/Trojan/protocol)
+[VMess + TCP + TLS 方式的 HTTP 分流和网站伪装](https://gist.github.com/liberal-boy/f3db4e413a96fa80719db1414f011325)
+[VMess Fail-Redirect 简单实现](https://gist.github.com/liberal-boy/04f875b86a5e54cb4e1752d24077f2be)

--- a/zh_CN/advanced/simple_tls_route_by_nginx.md
+++ b/zh_CN/advanced/simple_tls_route_by_nginx.md
@@ -1,4 +1,4 @@
-# 基于 Nginx 的简单 TLS 分流方案
+# 基于 Nginx 的简单 TLS 分流
 本节提供了基于协议数据的统一的代理分流方案，其使用 Nginx 作为前端对基于 TLS 承载的数据进行分流，简化了现有的 TCP+TLS+Web 方案并同时支持分流到 Trojan或 V2Ray 的 HTTP2。
 ## 目的
 看到有人根据 Trojan 原理基于 V2Ray 做了个类似功能的定制即 TCP + TLS + Web，就是在 TLS 层上传输 VMess 或者其他比如 http web 流量。

--- a/zh_CN/basics/dns.md
+++ b/zh_CN/basics/dns.md
@@ -85,12 +85,12 @@ DNS 服务是可以用来分流的，大致思路是，”哪些域名要去哪�
 
 服务端的 DNS 一般无需复杂配置。如果配置了，应注意`freedom`的 outbound 应配置了`"domainStrategy"`为`"UseIP" | "UseIPv4" | "UseIPv6"`几种的时候才会使用内置 DNS，默认的`AsIs`是交给操作系统去解析和连接。
 
-新版本 4.22.0+后加入的 DOH 功能，部署在服务器端时候可以简单使用。
+新版本 4.22.0+ 后加入的 DOH 功能，部署在服务器端时候可以简单使用。
 
 
 ## 对外开放 v2ray 的 DNS 服务
 
-Kitsunebi 的作者在[《漫谈各种黑科技式 DNS 技术在代理环境中的应用》](https://medium.com/@TachyonDevel/%E6%BC%AB%E8%B0%88%E5%90%84%E7%A7%8D%E9%BB%91%E7%A7%91%E6%8A%80%E5%BC%8F-dns-%E6%8A%80%E6%9C%AF%E5%9C%A8%E4%BB%A3%E7%90%86%E7%8E%AF%E5%A2%83%E4%B8%AD%E7%9A%84%E5%BA%94%E7%94%A8-62c50e58cbd0)中介绍了通过`Dokodemo`入站协议和`DNS`出站协议开放 v2ray DNS 的方法，可以充分发挥 v2ray 内置 DNS 的强大能力，例如让系统其它不经代理的联网程序获得 DNS 级别广告过滤的能力，以及在透明代理中接管系统 DNS 等。
+Kitsunebi 的作者在 [《漫谈各种黑科技式 DNS 技术在代理环境中的应用》](https://medium.com/@TachyonDevel/%E6%BC%AB%E8%B0%88%E5%90%84%E7%A7%8D%E9%BB%91%E7%A7%91%E6%8A%80%E5%BC%8F-dns-%E6%8A%80%E6%9C%AF%E5%9C%A8%E4%BB%A3%E7%90%86%E7%8E%AF%E5%A2%83%E4%B8%AD%E7%9A%84%E5%BA%94%E7%94%A8-62c50e58cbd0) 中介绍了通过`Dokodemo`入站协议和`DNS`出站协议开放 v2ray DNS 的方法，可以充分发挥 v2ray 内置 DNS 的强大能力，例如让系统其它不经代理的联网程序获得 DNS 级别广告过滤的能力，以及在透明代理中接管系统 DNS 等。
 
 该方法的核心思想是使用`Dokodemo`入站协议接收 DNS 请求流量，转发至`DNS`出站协议。而`DNS`出站协议会拦截`Type A`和`Type AAAA`的 DNS 查询并交由 v2ray 内置 DNS 处理，从而返回查询结果；除此之外的查询流量，会根据`Dokodemo`的配置发送至目标 DNS 服务器。
 
@@ -131,7 +131,7 @@ Kitsunebi 的作者在[《漫谈各种黑科技式 DNS 技术在代理环境中�
 }
 ```
 
-然而，这样配置存在一定问题。对于非`Type A`和`Type AAAA`的 DNS 查询，v2ray 将会直连转发至`dns-in`中所设置的目标 DNS 服务器。而当这个域名被污染时，返回的自然是被污染的结果；如果希望 v2ray 内置 DNS 承担 `DNSCrypt-Proxy` 的作用，这样无疑会导致DNS查询内容的泄露。
+然而，这样配置存在一定问题。对于非`Type A`和`Type AAAA`的 DNS 查询，v2ray 将会直连转发至`dns-in`中所设置的目标 DNS 服务器。而当这个域名被污染时，返回的自然是被污染的结果；如果希望 v2ray 内置 DNS 承担 `DNSCrypt-Proxy` 的作用，这样无疑会导致 DNS 查询内容的泄露。
 
 解决方法有两种：
 1. 在`dns-out`中，添加`proxySettings`的配置，使得非`Type A`和`Type AAAA`的 DNS 查询经由`remote-proxy-out`转发至远端解析。此时，目标为`8.8.8.8:53`的非`Type A`和`Type AAAA`的 DNS 查询流量通过代理转发至远端，并通过远端 v2ray 的`freedom`出站，发往`8.8.8.8:53`从而返回未经污染的结果。
@@ -170,12 +170,12 @@ V2Ray 4.22.0 新加入的功能，也没特殊配置的地方，就是上述配�
 }
 ```
 
-DOH 服务商不像传统 DNS 那么成熟，目前网上提供 DOH 的服务商可以参考[curl - DNS over HTTPS](https://github.com/curl/curl/wiki/DNS-over-HTTPS)
+DOH 服务商不像传统 DNS 那么成熟，目前网上提供 DOH 的服务商可以参考 [curl - DNS over HTTPS](https://github.com/curl/curl/wiki/DNS-over-HTTPS)
 
 注意，多数服务商的 DOH 的 tls 证书是没有对 IP 地址签发认证的，必须写实际的域名，但也有一些 DoH 提供商可以直接使用 IP 作为主机名访问，例如 CloudFlare 的`1.1.1.1`和阿里云公共 DNS 的`223.5.5.5`。
 
 DOH 把 DNS 请求融入到常见的 https 流量当中，完全使用 DOH 可以避免出入口 ISP 知道你访问的域名。
-但需要注意，只有在客户端、服务端都使用 DOH 协议(客户端使用 https 模式，服务端使用 https+local 模式)时候，VPS 出口上才不会出现传统的 UDP DNS 请求。
+但需要注意，只有在客户端、服务端都使用 DOH 协议（客户端使用 https 模式，服务端使用 https+local 模式）时候，VPS 出口上才不会出现传统的 UDP DNS 请求。
 
 DOH 的解析时间比传统的 UDP 要高不少，把 V2Ray 的 log level 设置为 debug 可以看到具体的域名解析耗时值。
 
@@ -198,7 +198,7 @@ DOH 的解析时间比传统的 UDP 要高不少，把 V2Ray 的 log level 设�
 
 ## 参考阅读
 
-详见[《漫谈各种黑科技式 DNS 技术在代理环境中的应用》](https://medium.com/@TachyonDevel/%E6%BC%AB%E8%B0%88%E5%90%84%E7%A7%8D%E9%BB%91%E7%A7%91%E6%8A%80%E5%BC%8F-dns-%E6%8A%80%E6%9C%AF%E5%9C%A8%E4%BB%A3%E7%90%86%E7%8E%AF%E5%A2%83%E4%B8%AD%E7%9A%84%E5%BA%94%E7%94%A8-62c50e58cbd0)，这篇文章为 Kitsunebi 的作者所写，很详细地分析了 V2Ray 关于 DNS 的机制及一些独有的骚操作，如果你有关于透明代理的需求，我认为很值得一看。如果没有那就随意吧。
+详见 [《漫谈各种黑科技式 DNS 技术在代理环境中的应用》](https://medium.com/@TachyonDevel/%E6%BC%AB%E8%B0%88%E5%90%84%E7%A7%8D%E9%BB%91%E7%A7%91%E6%8A%80%E5%BC%8F-dns-%E6%8A%80%E6%9C%AF%E5%9C%A8%E4%BB%A3%E7%90%86%E7%8E%AF%E5%A2%83%E4%B8%AD%E7%9A%84%E5%BA%94%E7%94%A8-62c50e58cbd0)，这篇文章为 Kitsunebi 的作者所写，很详细地分析了 V2Ray 关于 DNS 的机制及一些独有的骚操作，如果你有关于透明代理的需求，我认为很值得一看。如果没有那就随意吧。
 
 
 ## DNS 答疑


### PR DESCRIPTION
基于协议数据的统一的代理分流工具。nignx作为前端，tls终止并基于tls承载的数据进行分流。简单易安装,仅仅添加21行代码。简化了V官方的TCP+TLS+WEB方案，替换了TCP+TLS分流器，也可以分流到trojan。