### PR TITLE
Fix Caddy V2 Websocket Configuration

### DIFF
--- a/zh_CN/advanced/wss_and_web.md
+++ b/zh_CN/advanced/wss_and_web.md
@@ -121,7 +121,6 @@ mydomain.me {
         curves x25519
     }
     @v2ray_websocket {
-        path /ray
         header Connection *Upgrade*
         header Upgrade websocket
     }


### PR DESCRIPTION
Caddy v2配置中的 `path /ray` 这一行会导致其无法按预期工作。caddy社区的讨论也说明了这个问题：
https://caddy.community/t/caddy-v2-how-to-proxy-websoket-v2ray-websocket-tls/7040/12