### PR TITLE
Update h2_tls_web.md to Caddy v2 and h2c

### DIFF
--- a/zh_CN/advanced/h2_tls_web.md
+++ b/zh_CN/advanced/h2_tls_web.md
@@ -13,7 +13,6 @@ H2 流量理论上跟 ws 一样可以被 CDN 转发。 但是遗憾的是, Cloud
 
 ## 缺陷
 
-- 没有使用 [h2c](https://v2ray.com/chapter_00/01_versions.html#20190712-v4200)
 - 没有使用 [DomainSocket](https://v2ray.com/chapter_02/transport/domainsocket.html)
 - 其他尚未注明的缺陷，急需你的补充。
 


### PR DESCRIPTION
更新教程中 Caddy v1 的配置文件到 Caddy v2，补充在 Caddy 和 V2Ray 之间 h2c 链接的配置。
相关 issue #171 HTTP/2+TLS+WEB 更新至 Caddy 2 配置失败