### PR TITLE
fix #260

### DIFF
--- a/zh_CN/advanced/wss_and_web.md
+++ b/zh_CN/advanced/wss_and_web.md
@@ -25,7 +25,7 @@
         "clients": [
           {
             "id": "b831381d-6324-4d53-ad4f-8cda48b30811",
-            "alterId": 64
+            "alterId": 0
           }
         ]
       },


### PR DESCRIPTION
https://github.com/Jrohy/multi-v2ray/issues/561
自 2022 年 1 月 1 日起，服务器端将默认禁用对于 MD5 认证信息 的兼容。任何使用 MD5 认证信息的客户端将无法连接到禁用 VMess MD5 认证信息的服务器端。
alterId设为0就代表开启VMessAEAD，而不是VMess md5。