### PR TITLE
将`透明代理(TPROXY)`放在`透明代理(REDIRECT)`之上

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -140,8 +140,8 @@ function i18nSidebar(locale) {
       title: i18n(locale, 'practical'),
       path: i18nPath(locale, '/app/app'),
       children: i18nPath(locale, [
-        'app/transparent_proxy',
         'app/tproxy',
+        'app/transparent_proxy',
         'app/reverse',
         'app/reverse2',
         'app/parent',


### PR DESCRIPTION
我们现在更加推荐`透明代理(TPROXY)`方式，所以将`透明代理(TPROXY)`排序放在`透明代理(REDIRECT)`之前