### PR TITLE
Update wss_and_web.md

### DIFF
--- a/zh_CN/advanced/wss_and_web.md
+++ b/zh_CN/advanced/wss_and_web.md
@@ -90,7 +90,7 @@ server {
         return 404;
     }
     proxy_redirect off;
-    proxy_pass http://127.0.0.1:10000; # 假设WebSocket监听在环回地址的10000端口上
+    proxy_pass http://127.0.0.1:10000/ray; # 假设WebSocket监听在环回地址的10000端口上
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "upgrade";


### PR DESCRIPTION
更改了proxy_pass一行，因为原来的proxy_pass http://127.0.0.1:10000 会导致v2ray收到路径“/”而不是路径“/ray”，进而返回404，从而使nginx返回nginx的404页面